### PR TITLE
Add Package type and Min Firmware to ID field for easier navigation in HB-Store

### DIFF
--- a/src/hb.js
+++ b/src/hb.js
@@ -10,11 +10,22 @@ export default {
         let patchedFilename = (file.charAt(0) == "/") ? file.substr(1).replace(/[^a-zA-Z0-9-_./]/g, '') : file.replace(/[^a-zA-Z0-9-_./]/g, '')
         let stats = fs.lstatSync(file)
         let size = this.formatBytes(stats.size, 2)
-
+        let minfw = ((data.paramSfo.SYSTEM_VER >> 24) & 0xff).toString().substring(0,2) + "." + ((data.paramSfo.SYSTEM_VER >> 16) & 0xff).toString().substring(0,2)
+        let pkgtype = "Unknown"
+        let id = data.paramSfo.TITLE_ID
+        if (data.paramSfo.CATEGORY == "gd") {
+          id = "Base_Game_" + parseFloat(data.paramSfo.APP_VER).toFixed(2) + "_(Fw_" + minfw + ")_" + data.paramSfo.TITLE_ID
+          pkgtype = "Base Game"
+        } else if (data.paramSfo.CATEGORY == "gp") {
+          id = "Update_" + parseFloat(data.paramSfo.APP_VER).toFixed(2) + "_(Fw_" + minfw + ")_" + data.paramSfo.TITLE_ID
+          pkgtype = "Update"
+        } else if (data.paramSfo.CATEGORY == "ac") {
+          id = "DLC_" + data.paramSfo.TITLE_ID
+          pkgtype = "DLC"
+        }
         let item = {
           "pid": pid,
-          //"id": data.paramSfo.TITLE_ID,
-          "id": data.paramSfo.NPS_TYPE + " " + data.paramSfo.APP_VER + " (" + data.paramSfo.MIN_FW + ")",
+          "id": id,
           "name": data.paramSfo.TITLE,
           "desc": "",
           "image": "__image",
@@ -26,7 +37,7 @@ export default {
           "ReviewStars": "Custom Rating",
           "Size": size,
           "Author": "HB-Store CDN",
-          "apptype": "HB Game",
+          "apptype": pkgtype,
           "pv": "5.05+",
           "main_icon_path": "__image",
           "main_menu_pic": "/user/app/NPXS39041/storedata/" + data.paramSfo.TITLE_ID + ".png",

--- a/src/hb.js
+++ b/src/hb.js
@@ -13,7 +13,8 @@ export default {
 
         let item = {
           "pid": pid,
-          "id": data.paramSfo.TITLE_ID,
+          //"id": data.paramSfo.TITLE_ID,
+          "id": data.paramSfo.NPS_TYPE + " " + data.paramSfo.APP_VER + " (" + data.paramSfo.MIN_FW + ")",
           "name": data.paramSfo.TITLE,
           "desc": "",
           "image": "__image",


### PR DESCRIPTION
I parsed I couple more SFO fields to determine if packages are Base games, updates or DLC and what the Minimum firmware (as reported by the SFO header) is. 
I stick them in the ID string so they are displayed when navigating in HB-Store. 
I find this to be much easier to navigate.

I could not use spaces in ID string due to conflicts in HB-Store code so underscores_ were used instead. 